### PR TITLE
build(prisma): add RHEL OpenSSL 3.0.x binary target

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "rhel-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
- Add RHEL OpenSSL 3.0.x binary target to Prisma client configuration