### PR TITLE
refactor(server): destructure PrismaClient from prismaPkg

### DIFF
--- a/src/lib/server/prisma.ts
+++ b/src/lib/server/prisma.ts
@@ -1,4 +1,6 @@
-import { PrismaClient } from '@prisma/client';
+import prismaPkg from '@prisma/client';
+
+const { PrismaClient } = prismaPkg;
 
 const prisma = globalThis.__prisma ?? new PrismaClient();
 


### PR DESCRIPTION
- Import prismaPkg instead of directly importing PrismaClient
- Destructure PrismaClient from prismaPkg
- This change improves code readability and follows destructuring best practices