### PR TITLE
fix(Dockerfile): correct COPY command for node_modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN npm run build
 FROM base AS production
 ENV NODE_ENV=production
 COPY package.json package-lock.json ./
-COPY --from=deps /app/node_modules ./node_modules
+COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/build ./build
 EXPOSE 3000
 CMD ["node", "build"]


### PR DESCRIPTION
- Update COPY command to copy node_modules from 'builder' stage instead of 'deps'
- This ensures the correct build artifacts are used in the production stage